### PR TITLE
Removing example text

### DIFF
--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/ContentControlListEntries.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/ContentControlListEntries.xml
@@ -26,7 +26,7 @@
     <remarks>
       <para>Use the <see cref="M:Microsoft.Office.Interop.Word.ContentControlListEntries.Add(System.String,System.String,System.Int32)" /> method to add an item to a drop-down list or combo box. </para>
       <para>Use the <see cref="P:Microsoft.Office.Interop.Word.ContentControlListEntries.Item(System.Int32)" /> method or the <see cref="P:Microsoft.Office.Interop.Word.ContentControl.DropdownListEntries" /> property of a <see cref="T:Microsoft.Office.Interop.Word.ContentControl" /> object to access an individual list item within a collection. </para>
-      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.ContentControlListEntries.Clear" /> method to remove all items from a drop-down list or combo box. The following example clears all items from the first content control in the active document.</para>
+      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.ContentControlListEntries.Clear" /> method to remove all items from a drop-down list or combo box.</para>
       <para />
     </remarks>
   </Docs>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/DataLabels.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/DataLabels.xml
@@ -28,7 +28,7 @@
       <para />
     </remarks>
     <example>
-      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.Series.DataLabels(System.Object)" /> method to return the <see cref="T:Microsoft.Office.Interop.Word.DataLabels" /> collection. The following example sets the number format for data labels on the first series of the first chart in the active document.</para>
+      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.Series.DataLabels(System.Object)" /> method to return the <see cref="T:Microsoft.Office.Interop.Word.DataLabels" /> collection.</para>
       <para>Use <see cref="T:Microsoft.Office.Interop.Word.DataLabels" /> (<paramref name="Index" />), where <paramref name="Index" /> is the data label index number, to return a single <see cref="T:Microsoft.Office.Interop.Word.DataLabel" /> object.</para>
     </example>
   </Docs>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/ErrorBars.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/ErrorBars.xml
@@ -25,7 +25,7 @@
       <para />
     </remarks>
     <example>
-      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Series.ErrorBars" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.ErrorBars" /> object. The following example turns on error bars for series one of the first chart in the active document and then sets the end style for the error bars.</para>
+      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Series.ErrorBars" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.ErrorBars" /> object.</para>
     </example>
   </Docs>
   <Members>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/Floor.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/Floor.xml
@@ -21,7 +21,7 @@
     <summary>Represents the floor of a 3-D chart.</summary>
     <remarks>To be added.</remarks>
     <example>
-      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Chart.Floor" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.Floor" /> object. The following example sets the floor color for embedded chart one to cyan. The example will fail if the chart isn’t a 3-D chart.</para>
+      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Chart.Floor" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.Floor" /> object.</para>
     </example>
   </Docs>
   <Members>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/LeaderLines.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/LeaderLines.xml
@@ -25,7 +25,7 @@
       <para />
     </remarks>
     <example>
-      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Series.LeaderLines" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.LeaderLines" /> object. The following example adds data labels and blue leader lines to series one on the first chart in the active document. If no leader lines are visible this example code will fail. In this situation, you can manually drag one of the data labels away from the pie chart to make a leader line show up.</para>
+      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Series.LeaderLines" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.LeaderLines" /> object.</para>
     </example>
   </Docs>
   <Members>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/Legend.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/Legend.xml
@@ -25,7 +25,7 @@
       <para />
     </remarks>
     <example>
-      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Chart.Legend" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.Legend" /> object. The following example sets the font style for the legend of the first chart in the active document to bold.</para>
+      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Chart.Legend" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.Legend" /> object.</para>
     </example>
   </Docs>
   <Members>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/LegendEntries.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/LegendEntries.xml
@@ -28,7 +28,7 @@
       <para />
     </remarks>
     <example>
-      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.Legend.LegendEntries(System.Object)" /> method to return the <see cref="T:Microsoft.Office.Interop.Word.LegendEntries" /> collection. The following example loops through the collection of legend entries for the first chart in the active document and changes their font color.</para>
+      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.Legend.LegendEntries(System.Object)" /> method to return the <see cref="T:Microsoft.Office.Interop.Word.LegendEntries" /> collection.</para>
       <para>Use <see cref="T:Microsoft.Office.Interop.Word.LegendEntries" /> (<paramref name="index" />), where <paramref name="index" /> is the legend entry index number, to return a single <see cref="T:Microsoft.Office.Interop.Word.LegendKey" /> object. You cannot return legend entries by name.</para>
       <para>The index number represents the position of the legend entry in the legend. LegendEntries(1) is at the top of the legend; LegendEntries(LegendEntries.Count) is at the bottom.</para>
     </example>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/OMath.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/OMath.xml
@@ -20,7 +20,7 @@
   <Docs>
     <summary>Represents an equation. <see cref="T:Microsoft.Office.Interop.Word.OMath" /> objects are members of the <see cref="T:Microsoft.Office.Interop.Word.OMaths" /> collection.</summary>
     <remarks>
-      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.OMaths.Add(Microsoft.Office.Interop.Word.Range)" /> method of the <see cref="T:Microsoft.Office.Interop.Word.OMaths" /> collection to create an equation and add it to a document, selection, or range.  The following example creates an equation and uses the <see cref="M:Microsoft.Office.Interop.Word.OMaths.Buildup" /> method to convert the equation to professional format.</para>
+      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.OMaths.Add(Microsoft.Office.Interop.Word.Range)" /> method of the <see cref="T:Microsoft.Office.Interop.Word.OMaths" /> collection to create an equation and add it to a document, selection, or range.</para>
       <para />
     </remarks>
   </Docs>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/OMaths.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/OMaths.xml
@@ -24,7 +24,7 @@
   <Docs>
     <summary>A collection of equations. Use the <see cref="T:Microsoft.Office.Interop.Word.OMaths" /> object to access individual members of the collection.</summary>
     <remarks>
-      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.OMaths.Add(Microsoft.Office.Interop.Word.Range)" />method to create an equation and add it to a document, selection, or range.  The following example creates an equation and uses the <see cref="M:Microsoft.Office.Interop.Word.OMaths.BuildUp" /> method of the <see cref="T:Microsoft.Office.Interop.Word.OMaths" /> collection to convert the equation to professional format.</para>
+      <para>Use the <see cref="M:Microsoft.Office.Interop.Word.OMaths.Add(Microsoft.Office.Interop.Word.Range)" />method to create an equation and add it to a document, selection, or range.</para>
       <para />
     </remarks>
   </Docs>
@@ -55,9 +55,7 @@
         <summary>Creates an equation, from the text equation contained within the specified range, and returns a <b>Range</b> object that contains the new equation.</summary>
         <returns>Range</returns>
         <remarks>To be added.</remarks>
-        <example>
-          <para>The following example inserts an equation into the document at the cursor or replacing the selected text.</para>
-        </example>
+        
       </Docs>
     </Member>
     <Member MemberName="Application">

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/PlotArea.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/PlotArea.xml
@@ -25,7 +25,7 @@
       <para />
     </remarks>
     <example>
-      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Chart.PlotArea" /> property to return a <see cref="T:Microsoft.Office.Interop.Word.PlotArea" /> object. The following example places a dashed border around the chart area of the first chart in the active document, and then places a dotted border around the plot area.</para>
+      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Chart.PlotArea" /> property to return a <see cref="T:Microsoft.Office.Interop.Word.PlotArea" /> object. </para>
     </example>
   </Docs>
   <Members>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/Trendline.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/Trendline.xml
@@ -26,7 +26,7 @@
     <example>
       <para>Use <see cref="T:Microsoft.Office.Interop.Word.Trendlines" /> (<paramref name="Index" />), where <paramref name="Index" /> is the trendline index number, to return a single <see cref="T:Microsoft.Office.Interop.Word.Trendline" /> object.</para>
       <para>The index number denotes the order in which the trendlines were added to the series. Trendlines(1) is the first trendline added to the series, and Trendlines(Trendlines.Count) is the last one added.</para>
-      <para>The following example changes the trendline type for the first series of the first chart in the active document. If the series has no trendline, this example will fail.</para>
+   
     </example>
   </Docs>
   <Members>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/UpBars.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/UpBars.xml
@@ -25,7 +25,7 @@
       <para />
     </remarks>
     <example>
-      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.ChartGroup.UpBars" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.UpBars" /> object. The following example turns on up and down bars for chart group one of the first chart in the active document. The example then sets the up bar color to blue and sets the down bar color to red.</para>
+      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.ChartGroup.UpBars" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.UpBars" /> object. </para>
     </example>
   </Docs>
   <Members>

--- a/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/Walls.xml
+++ b/officedocs-dev-word-pia/xml/Microsoft.Office.Interop.Word/Walls.xml
@@ -21,7 +21,7 @@
     <summary>Represents the walls of a 3-D chart. This object isn’t a collection. There’s no object that represents a single wall; you must return all the walls as a unit.</summary>
     <remarks>To be added.</remarks>
     <example>
-      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Chart.Walls" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.Walls" /> object. The following example sets the pattern on the walls for the first chart in the active document. If the chart isn’t a 3-D chart, this example will fail.</para>
+      <para>Use the <see cref="P:Microsoft.Office.Interop.Word.Chart.Walls" /> property to return the <see cref="T:Microsoft.Office.Interop.Word.Walls" /> object. </para>
     </example>
   </Docs>
   <Members>


### PR DESCRIPTION
There were several articles that indicate an example existed, when none did. I removed the text that indicated there was an example.