### PR TITLE
Fix breadcrumbs

### DIFF
--- a/officedocs-dev-word-pia/breadcrumb/toc.yml
+++ b/officedocs-dev-word-pia/breadcrumb/toc.yml
@@ -1,2 +1,0 @@
-- name: Docs
-  tocHref: /

--- a/officedocs-dev-word-pia/docfx.json
+++ b/officedocs-dev-word-pia/docfx.json
@@ -40,9 +40,9 @@
     },
     "globalMetadata": {
       "feedback_system": "Standard",
-      "uhfHeaderId": "MSDocsHeader-DotNet",
+      "uhfHeaderId": "MSDocsHeader-M365-IT",
       "apiPlatform": "dotnet",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "/dotnet/officedocs-dev-word-pia-breadcrumb/toc.json",
       "ROBOTS": "INDEX,FOLLOW",
       "author": "o365devx",
       "ms.author": "o365devx",

--- a/officedocs-dev-word-pia/officedocs-dev-word-pia-breadcrumb/toc.yml
+++ b/officedocs-dev-word-pia/officedocs-dev-word-pia-breadcrumb/toc.yml
@@ -1,0 +1,7 @@
+- name: Microsoft 365
+  tocHref: /dotnet/
+  topicHref: /microsoft-365/index
+  items:
+  - name: .NET API browser
+    tocHref: /dotnet/
+    topicHref: /dotnet/api/index


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with platform architecture requirements. This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings and if PR Automerger service is available for this repo. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the approved breadcrumb pattern for a given product’s documentation.

Note: Also updated uhfHeaderId to M365 L2 header because this content is tagged as Word content, which should use M365 L2 header.